### PR TITLE
Fix player list assignment

### DIFF
--- a/Crickos/TeamDetail.swift
+++ b/Crickos/TeamDetail.swift
@@ -54,7 +54,7 @@ struct TeamDetail: View {
                 let _ = print(data.description)
                 if(data.isEmpty){return}
                 let tempObj = try JSONDecoder().decode(PlayerBriefInfoModel.self, from: data)
-                players.self = tempObj.data
+                players = tempObj.data
                 var _: String = ""
             }
             catch


### PR DESCRIPTION
## Summary
- fix player array assignment when loading team detail

## Testing
- `swiftc Crickos/TeamDetail.swift -o /tmp/td` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6840d187bfd88326b5f20f44cb4948c5