### PR TITLE
Add unit test decoding Country

### DIFF
--- a/Crickos.xcodeproj/project.pbxproj
+++ b/Crickos.xcodeproj/project.pbxproj
@@ -24,8 +24,9 @@
 		7DCFE9402926848F003AE346 /* PlayerBriefInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCFE9362926848F003AE346 /* PlayerBriefInfo.swift */; };
 		7DCFE9412926848F003AE346 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCFE9372926848F003AE346 /* ImageLoader.swift */; };
 		7DCFE9422926848F003AE346 /* AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCFE9382926848F003AE346 /* AsyncImage.swift */; };
-		7DCFE9432926848F003AE346 /* EnvironmentValues+ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCFE9392926848F003AE346 /* EnvironmentValues+ImageCache.swift */; };
-		7DCFE9442926848F003AE346 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCFE93A2926848F003AE346 /* ImageCache.swift */; };
+                7DCFE9432926848F003AE346 /* EnvironmentValues+ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCFE9392926848F003AE346 /* EnvironmentValues+ImageCache.swift */; };
+                7DCFE9442926848F003AE346 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCFE93A2926848F003AE346 /* ImageCache.swift */; };
+               7DCFE9452926848F003AE347 /* CountryDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCFE9462926848F003AE347 /* CountryDecodingTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,18 +48,27 @@
 		7DCFE9362926848F003AE346 /* PlayerBriefInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerBriefInfo.swift; sourceTree = "<group>"; };
 		7DCFE9372926848F003AE346 /* ImageLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		7DCFE9382926848F003AE346 /* AsyncImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncImage.swift; sourceTree = "<group>"; };
-		7DCFE9392926848F003AE346 /* EnvironmentValues+ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+ImageCache.swift"; sourceTree = "<group>"; };
-		7DCFE93A2926848F003AE346 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
+                7DCFE9392926848F003AE346 /* EnvironmentValues+ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+ImageCache.swift"; sourceTree = "<group>"; };
+                7DCFE93A2926848F003AE346 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
+               7DCFE9462926848F003AE347 /* CountryDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryDecodingTests.swift; sourceTree = "<group>"; };
+               7DCFE94B2926848F003AE347 /* CrickosTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CrickosTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		7DCFE91D29268403003AE346 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                7DCFE91D29268403003AE346 /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+               7DCFE9482926848F003AE347 /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -70,22 +80,24 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		7DCFE91729268403003AE346 = {
-			isa = PBXGroup;
-			children = (
-				7DCFE92229268403003AE346 /* Crickos */,
-				7DCFE92129268403003AE346 /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		7DCFE92129268403003AE346 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				7DCFE92029268403003AE346 /* Crickos.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
+                7DCFE91729268403003AE346 = {
+                        isa = PBXGroup;
+                        children = (
+                                7DCFE92229268403003AE346 /* Crickos */,
+                                7DCFE92129268403003AE346 /* Products */,
+                                7DCFE94F2926848F003AE347 /* CrickosTests */,
+                        );
+                        sourceTree = "<group>";
+                };
+                7DCFE92129268403003AE346 /* Products */ = {
+                        isa = PBXGroup;
+                        children = (
+                                7DCFE92029268403003AE346 /* Crickos.app */,
+                                7DCFE94B2926848F003AE347 /* CrickosTests.xctest */,
+                        );
+                        name = Products;
+                        sourceTree = "<group>";
+                };
 		7DCFE92229268403003AE346 /* Crickos */ = {
 			isa = PBXGroup;
 			children = (
@@ -112,34 +124,59 @@
 			path = Crickos;
 			sourceTree = "<group>";
 		};
-		7DCFE92929268405003AE346 /* Preview Content */ = {
-			isa = PBXGroup;
-			children = (
-				7DCFE92A29268405003AE346 /* Preview Assets.xcassets */,
-			);
-			path = "Preview Content";
-			sourceTree = "<group>";
-		};
+                7DCFE92929268405003AE346 /* Preview Content */ = {
+                        isa = PBXGroup;
+                        children = (
+                                7DCFE92A29268405003AE346 /* Preview Assets.xcassets */,
+                        );
+                        path = "Preview Content";
+                        sourceTree = "<group>";
+                };
+               7DCFE94F2926848F003AE347 /* CrickosTests */ = {
+                        isa = PBXGroup;
+                        children = (
+                                7DCFE9462926848F003AE347 /* CountryDecodingTests.swift */,
+                        );
+                        path = CrickosTests;
+                        sourceTree = "<group>";
+                };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		7DCFE91F29268403003AE346 /* Crickos */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 7DCFE92E29268405003AE346 /* Build configuration list for PBXNativeTarget "Crickos" */;
-			buildPhases = (
-				7DCFE91C29268403003AE346 /* Sources */,
-				7DCFE91D29268403003AE346 /* Frameworks */,
-				7DCFE91E29268403003AE346 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Crickos;
-			productName = Crickos;
-			productReference = 7DCFE92029268403003AE346 /* Crickos.app */;
-			productType = "com.apple.product-type.application";
-		};
+                7DCFE91F29268403003AE346 /* Crickos */ = {
+                        isa = PBXNativeTarget;
+                        buildConfigurationList = 7DCFE92E29268405003AE346 /* Build configuration list for PBXNativeTarget "Crickos" */;
+                        buildPhases = (
+                                7DCFE91C29268403003AE346 /* Sources */,
+                                7DCFE91D29268403003AE346 /* Frameworks */,
+                                7DCFE91E29268403003AE346 /* Resources */,
+                        );
+                        buildRules = (
+                        );
+                        dependencies = (
+                        );
+                        name = Crickos;
+                        productName = Crickos;
+                        productReference = 7DCFE92029268403003AE346 /* Crickos.app */;
+                        productType = "com.apple.product-type.application";
+                };
+               7DCFE94A2926848F003AE347 /* CrickosTests */ = {
+                        isa = PBXNativeTarget;
+                        buildConfigurationList = 7DCFE94C2926848F003AE347 /* Build configuration list for PBXNativeTarget "CrickosTests" */;
+                        buildPhases = (
+                                7DCFE9472926848F003AE347 /* Sources */,
+                                7DCFE9482926848F003AE347 /* Frameworks */,
+                                7DCFE9492926848F003AE347 /* Resources */,
+                        );
+                        buildRules = (
+                        );
+                        dependencies = (
+                        );
+                        name = CrickosTests;
+                        productName = CrickosTests;
+                        productReference = 7DCFE94B2926848F003AE347 /* CrickosTests.xctest */;
+                        productType = "com.apple.product-type.bundle.unit-test";
+                };
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -167,23 +204,31 @@
 			productRefGroup = 7DCFE92129268403003AE346 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
-			targets = (
-				7DCFE91F29268403003AE346 /* Crickos */,
-			);
-		};
+                        targets = (
+                                7DCFE91F29268403003AE346 /* Crickos */,
+                                7DCFE94A2926848F003AE347 /* CrickosTests */,
+                        );
+                };
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		7DCFE91E29268403003AE346 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7D1C3BB429293FE900A3859D /* Preview Content in Resources */,
-				7DCFE92B29268405003AE346 /* Preview Assets.xcassets in Resources */,
-				7DCFE92829268405003AE346 /* Assets.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                7DCFE91E29268403003AE346 /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                7D1C3BB429293FE900A3859D /* Preview Content in Resources */,
+                                7DCFE92B29268405003AE346 /* Preview Assets.xcassets in Resources */,
+                                7DCFE92829268405003AE346 /* Assets.xcassets in Resources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+               7DCFE9492926848F003AE347 /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -206,10 +251,18 @@
 				7DCFE93B2926848F003AE346 /* Countries.swift in Sources */,
 				7DCFE92429268403003AE346 /* CrickosApp.swift in Sources */,
 				7DCFE9432926848F003AE346 /* EnvironmentValues+ImageCache.swift in Sources */,
-				7DCFE93E2926848F003AE346 /* CountiesList.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                7DCFE93E2926848F003AE346 /* CountiesList.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+               7DCFE9472926848F003AE347 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                7DCFE9452926848F003AE347 /* CountryDecodingTests.swift in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
@@ -356,35 +409,63 @@
 			};
 			name = Debug;
 		};
-		7DCFE93029268405003AE346 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"Crickos/Preview Content\"";
-				DEVELOPMENT_TEAM = X74F9NBK3C;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.allsolz.Crickos;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
+                7DCFE93029268405003AE346 /* Release */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_ASSET_PATHS = "\"Crickos/Preview Content\"";
+                                DEVELOPMENT_TEAM = X74F9NBK3C;
+                                ENABLE_PREVIEWS = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                                LD_RUNPATH_SEARCH_PATHS = (
+                                        "$(inherited)",
+                                        "@executable_path/Frameworks",
+                                );
+                                MARKETING_VERSION = 1.0;
+                                PRODUCT_BUNDLE_IDENTIFIER = com.allsolz.Crickos;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                SWIFT_EMIT_LOC_STRINGS = YES;
+                                SWIFT_VERSION = 5.0;
+                                TARGETED_DEVICE_FAMILY = "1,2";
+                        };
+                        name = Release;
+                };
+               7DCFE94D2926848F003AE347 /* Debug */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                CODE_SIGN_STYLE = Automatic;
+                                DEVELOPMENT_TEAM = X74F9NBK3C;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                PRODUCT_BUNDLE_IDENTIFIER = com.allsolz.CrickosTests;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                SWIFT_VERSION = 5.0;
+                                IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+                                TARGETED_DEVICE_FAMILY = "1,2";
+                        };
+                        name = Debug;
+                };
+               7DCFE94E2926848F003AE347 /* Release */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                CODE_SIGN_STYLE = Automatic;
+                                DEVELOPMENT_TEAM = X74F9NBK3C;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                PRODUCT_BUNDLE_IDENTIFIER = com.allsolz.CrickosTests;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                SWIFT_VERSION = 5.0;
+                                IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+                                TARGETED_DEVICE_FAMILY = "1,2";
+                        };
+                        name = Release;
+                };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -397,15 +478,24 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		7DCFE92E29268405003AE346 /* Build configuration list for PBXNativeTarget "Crickos" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				7DCFE92F29268405003AE346 /* Debug */,
-				7DCFE93029268405003AE346 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
+                7DCFE92E29268405003AE346 /* Build configuration list for PBXNativeTarget "Crickos" */ = {
+                        isa = XCConfigurationList;
+                        buildConfigurations = (
+                                7DCFE92F29268405003AE346 /* Debug */,
+                                7DCFE93029268405003AE346 /* Release */,
+                        );
+                        defaultConfigurationIsVisible = 0;
+                        defaultConfigurationName = Release;
+                };
+               7DCFE94C2926848F003AE347 /* Build configuration list for PBXNativeTarget "CrickosTests" */ = {
+                        isa = XCConfigurationList;
+                        buildConfigurations = (
+                                7DCFE94D2926848F003AE347 /* Debug */,
+                                7DCFE94E2926848F003AE347 /* Release */,
+                        );
+                        defaultConfigurationIsVisible = 0;
+                        defaultConfigurationName = Release;
+                };
 /* End XCConfigurationList section */
 	};
 	rootObject = 7DCFE91829268403003AE346 /* Project object */;

--- a/CrickosTests/CountryDecodingTests.swift
+++ b/CrickosTests/CountryDecodingTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Crickos
+
+final class CountryDecodingTests: XCTestCase {
+    func testDecodeCountry() throws {
+        let json = """
+        {
+            "resource": "countries",
+            "id": 1,
+            "continent_id": 5,
+            "name": "Testland",
+            "image_path": "https://example.com/test.png",
+            "updated_at": "2023-01-01T00:00:00+00:00"
+        }
+        """.data(using: .utf8)!
+
+        let country = try JSONDecoder().decode(Country.self, from: json)
+        XCTAssertEqual(country.id, 1)
+        XCTAssertEqual(country.name, "Testland")
+        XCTAssertEqual(country.image_path, "https://example.com/test.png")
+    }
+}


### PR DESCRIPTION
## Summary
- add a new test target `CrickosTests` to the Xcode project
- include `CountryDecodingTests.swift` which validates decoding of `Country`

## Testing
- `xcodebuild -list -project Crickos.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d289e624832695114413ecd2f8cc